### PR TITLE
Fixing ArrayIndexOutOfBoundsException on empty documents

### DIFF
--- a/src/cc/redpen/intellij/RedPenInspection.kt
+++ b/src/cc/redpen/intellij/RedPenInspection.kt
@@ -46,17 +46,21 @@ open class RedPenInspection : LocalInspectionTool() {
         val redPenDoc = redPen.parse(parser, text)
         val errors = redPen.validate(redPenDoc)
 
-        val element = file.children[0]
-        val lines = text.split("(?<=\n)".toRegex())
+        if (file.children.size > 0) {
+            val element = file.children[0]
+            val lines = text.split("(?<=\n)".toRegex())
 
-        val problems = errors.map({ e ->
-            val range = toRange(e, lines)
-            manager.createProblemDescriptor(element, range,
-                    e.message + " (" + e.validatorName + ")", GENERIC_ERROR_OR_WARNING, isOnTheFly,
-                    BaseQuickFix.forValidator(e.validatorName, text.substring(range.startOffset, range.endOffset)))
-        })
+            val problems = errors.map({ e ->
+                val range = toRange(e, lines)
+                manager.createProblemDescriptor(element, range,
+                        e.message + " (" + e.validatorName + ")", GENERIC_ERROR_OR_WARNING, isOnTheFly,
+                        BaseQuickFix.forValidator(e.validatorName, text.substring(range.startOffset, range.endOffset)))
+            })
 
-        return problems.toTypedArray()
+            return problems.toTypedArray()
+        } else {
+            return arrayOf()
+        }
     }
 
     override fun getDefaultLevel(): HighlightDisplayLevel {

--- a/test/cc/redpen/intellij/RedPenInspectionTest.kt
+++ b/test/cc/redpen/intellij/RedPenInspectionTest.kt
@@ -50,6 +50,13 @@ class RedPenInspectionTest : BaseTest() {
     }
 
     @Test
+    fun canParseEmptyDocument() {
+        whenever(redPen.validate(any<Document>())).thenReturn(emptyList())
+        inspection.checkFile(mockTextFile(""), mock(), true)
+        verify(redPen).parse(DocumentParser.PLAIN, "")
+    }
+
+    @Test
     fun toGlobalOffset_noOffset() {
         assertEquals(0, inspection.toGlobalOffset(null, listOf("")))
     }


### PR DESCRIPTION
Hello,
I've fixed the ArrayIndexOutOfBoundsException thrown on parsing empty documents.
This PR intends to resolve #1.

Please review and hopefully merge.
Best,
-t
