### PR TITLE
Fixing Mockito version at Mockito-Kotlin safe one

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -12,6 +12,6 @@
       <exclude org="org.slf4j"/>
       <exclude org="org.json"/>
     </dependency>
-    <dependency org="org.mockito" name="mockito-core" rev="2.0.+" conf="test->default"/>
+    <dependency org="org.mockito" name="mockito-core" rev="2.0.39-beta" conf="test->default"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
Hello,
I've found builds are breaking on argThat.
This PR intends to solve that issue through fixing Mockito version at the one Mockito-Kotlin uses (2.0.39-beta).
Please review and hopefully merge.
Best,
-t
